### PR TITLE
Avoid overlapping CIDRs and make ranges recognizable

### DIFF
--- a/cluster-d-qar.yaml
+++ b/cluster-d-qar.yaml
@@ -6,9 +6,9 @@ nodes:
 networking:
   disableDefaultCNI: true
   ipFamily: ipv4
-  podSubnet: 10.0.0.0/16
+  podSubnet: 10.241.0.0/16
   kubeProxyMode: none
-  serviceSubnet: 192.168.0.0/24
+  serviceSubnet: 10.111.0.0/24
 containerdConfigPatches:
   - |-
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]

--- a/cluster-jakku.yaml
+++ b/cluster-jakku.yaml
@@ -6,9 +6,9 @@ nodes:
 networking:
   disableDefaultCNI: true
   ipFamily: ipv4
-  podSubnet: 10.0.0.0/16
+  podSubnet: 10.240.0.0/16
   kubeProxyMode: none
-  serviceSubnet: 192.168.0.0/24
+  serviceSubnet: 10.110.0.0/24
 containerdConfigPatches:
   - |-
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]


### PR DESCRIPTION
This is a simple change that avoids using Overlapping CIDRs for the Pods and Services. And also picks numbers that are somewhat easy to see when looking at the IPs during the demo