### PR TITLE
Add ahch-to as a third cluster

### DIFF
--- a/cluster-ahch-to.yaml
+++ b/cluster-ahch-to.yaml
@@ -1,0 +1,15 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+name: ahch-to
+nodes:
+  - role: control-plane
+networking:
+  disableDefaultCNI: true
+  ipFamily: ipv4
+  podSubnet: 10.242.0.0/16
+  kubeProxyMode: none
+  serviceSubnet: 10.112.0.0/24
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
+      endpoint = ["http://kind-registry:5000"]

--- a/start-three-clusters.sh
+++ b/start-three-clusters.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -eux
+
+# On Linux, running three clusters needs these ctls increased:
+sudo sysctl fs.inotify.max_user_instances=1280
+sudo sysctl fs.inotify.max_user_watches=655360
+
+# First, start the other two clusters and get all env variables
+source ./start-multicluster-kind.sh
+
+# Create the additional dir and .envrc for this to work with direnv
+for cluster in ahch-to; do
+    mkdir -p $cluster
+    echo "export KUBECONFIG=./kubeconfig" > $cluster/.envrc
+done
+
+AHCHTO_KUBECONFIG=ahch-to/kubeconfig
+export KUBECONFIG=${JAKKU_KUBECONFIG}:${DQAR_KUBECONFIG}:${AHCHTO_KUBECONFIG}
+
+# Create Ahch-to cluster
+kind create cluster --config cluster-ahch-to.yaml --kubeconfig ${AHCHTO_KUBECONFIG}
+cat values-cluster-ahch-to.yaml | envsubst | cilium install --helm-values /dev/stdin --wait --chart-directory "${CHART_DIR}" --inherit-ca kind-jakku --cluster-name ahch-to --context kind-ahch-to
+cilium clustermesh enable --service-type NodePort --apiserver-image $DOCKER_REGISTRY/cilium/clustermesh-apiserver:$DOCKER_TAG --context kind-ahch-to
+cilium clustermesh status --wait --context kind-ahch-to
+cilium clustermesh connect --context kind-jakku --destination-context kind-ahch-to
+cilium clustermesh connect --context kind-d-qar --destination-context kind-ahch-to
+
+# Generate and copy the necessary YAML files
+cat jedi.spec.yaml | envsubst > ahch-to/jedi.yaml
+cp luke.yaml ahch-to/
+cp protect.yaml ahch-to/

--- a/stop-multi-cluster-kind.sh
+++ b/stop-multi-cluster-kind.sh
@@ -3,3 +3,4 @@
 docker network disconnect kind kind-registry
 kind delete cluster --name jakku
 kind delete cluster --name d-qar
+kind delete cluster --name ahch-to

--- a/values-cluster-ahch-to.yaml
+++ b/values-cluster-ahch-to.yaml
@@ -1,0 +1,54 @@
+tunnel: vxlan
+ipv4:
+  enabled: true
+ipv6:
+  enabled: false
+autoDirectNodeRoutes: false
+cluster:
+  name: ahch-to
+  id: 3
+image:
+  repository: ${DOCKER_REGISTRY}/cilium/cilium
+  tag: ${DOCKER_TAG}
+  useDigest: false
+  pullPolicy: Always
+operator:
+  image:
+    repository: ${DOCKER_REGISTRY}/cilium/operator
+    tag: ${DOCKER_TAG}
+    useDigest: false
+    pullPolicy: Always
+    suffix: ""
+clustermesh:
+  useAPIServer: true
+  config:
+    enabled: true
+    enableClusterAwareAddressing: true
+    hasOverlappingPodCIDR: true
+  apiserver:
+    image:
+      repository: ${DOCKER_REGISTRY}/cilium/clustermesh-apiserver
+      tag: ${DOCKER_TAG}
+      useDigest: false
+      pullPolicy: Always
+hubble:
+  relay:
+    image:
+      repository: ${DOCKER_REGISTRY}/cilium/hubble-relay
+      tag: ${DOCKER_TAG}
+      digest: ""
+      useDigest: false
+      pullPolicy: Always
+kubeProxyReplacement: strict
+bpf:
+  monitorAggregation: none
+  lbExternalClusterIP: true
+socketLB:
+  enabled: true
+  hostNamespaceOnly: true
+ipam:
+  mode: kubernetes
+k8s:
+  requireIPv4PodCIDR: true
+  requireIPv6PodCIDR: false
+enablePortal: true


### PR DESCRIPTION
This PR includes the script changes from #2, as well as creating and starting an additional Ahch-To cluster.

I'm filing this as a separate PR, because the original demo was using ahch-to as an external endpoint. This is still not available in the latest Cilium version (will likely not make it into 1.14), so when I did the demo I opted to show a third cluster instead, but perhaps this is not what you want.

One alternative would be to split the starting of the third cluster to a separate script, to make this optional. I can do that approach if you prefer.